### PR TITLE
DMB-837 Established a release process based on GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           docker cp autodba-release-container:/home/autodba/release_output ./release_output
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ./release_output/*
           body: "Automated release for tag ${{ github.ref }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  create
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-24.04
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image for release
+        run: |
+          docker build -f Dockerfile . --target release --tag autodbarelease
+
+      - name: Run release container
+        run: |
+          docker run -d --name autodba-release-container autodbarelease tail -f /dev/null
+
+      - name: Copy artifacts
+        run: |
+          docker cp autodba-release-container:/home/autodba/release_output ./release_output
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./release_output/*
+          body: "Automated release for tag ${{ github.ref }}"
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup Docker container
+        run: |
+          docker stop autodba-release-container
+          docker rm autodba-release-container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,9 @@ jobs:
         run: |
           docker build -f Dockerfile . --target release --tag autodbarelease
 
-      - name: Run release container
-        run: |
-          docker run -d --name autodba-release-container autodbarelease tail -f /dev/null
-
       - name: Copy artifacts
         run: |
-          docker cp autodba-release-container:/home/autodba/release_output ./release_output
+          docker run --rm -v ./release_output:/release_output autodbarelease /bin/bash -c "cp /home/autodba/release_output/* /release_output"
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -35,8 +31,3 @@ jobs:
           make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cleanup Docker container
-        run: |
-          docker stop autodba-release-container
-          docker rm autodba-release-container

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,8 @@ RUN ./scripts/build.sh && \
     mv build_output/tar.gz/autodba-0.1.0.tar.gz release_output/  && \
     mv build_output/rpm/autodba*.rpm release_output/ && \
     mv build_output/deb/autodba*.deb release_output/ && \
+    cp ./scripts/install.sh release_output/ && \
+    cp ./scripts/uninstall.sh release_output/ && \
     rm -rf build_output
 
 FROM bff_builder AS test

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,7 @@ RUN apt-get install -y --no-install-recommends rpm ruby ruby-dev rubygems build-
 COPY ./ ./
 RUN ./scripts/build.sh && \
     mkdir -p release_output && \
-    mv build_output/source/autodba-0.1.0-source.tar.gz release_output/ && \
     mv build_output/tar.gz/autodba-0.1.0.tar.gz release_output/  && \
-    mv build_output/rpm/autodba*.rpm release_output/ && \
-    mv build_output/deb/autodba*.deb release_output/ && \
     cp ./scripts/install.sh release_output/ && \
     cp ./scripts/uninstall.sh release_output/ && \
     rm -rf build_output


### PR DESCRIPTION
Also, added `install.sh` and `uninstall.sh` to the release artifacts.

This PR is tested on a separate private repo and it works as expected.