### PR TITLE
DBA-39 Collector API Server stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,4 @@ devenv.local.nix
 autodba_backups_dir
 bff/main
 build_output/
-pganalyze.db
+crystaldb-collector.db

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ devenv.local.nix
 autodba_backups_dir
 bff/main
 build_output/
+pganalyze.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.2.0	2024-09-19
+
+### Added
+- Time bar for access to historical data
+- Allow operation without AWS credentials
+
+### Changed
+- Simplified packaging and installation
+
+### Fixed
+- Ensure consistent UI performance with limits and throttling
+
 ## 0.1.0	2024-09-06
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,9 @@ RUN mkdir -p /usr/local/autodba/share/collector && \
 
 
 FROM go_builder as collector_api_server_builder
-RUN mkdir -p /usr/local/autodba/share/collector_api_server
+WORKDIR /usr/local/autodba/share/collector_api_server
 COPY collector-api/ /usr/local/autodba/share/collector_api_server/
-RUN cd /usr/local/autodba/share/collector_api_server/ && \
-    go build -o collector-api-server ./cmd/server/main.go
+RUN go build -o collector-api-server ./cmd/server/main.go
 
 FROM go_builder as bff_builder
 # Build bff
@@ -114,6 +113,9 @@ RUN go test ./pkg/server/promql_codegen_test.go -v
 RUN go test ./pkg/server -v
 RUN go test ./pkg/metrics -v
 RUN go test ./pkg/prometheus -v
+
+WORKDIR /home/autodba/collector-api
+RUN go test -v ./...
 
 FROM base AS autodba
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,12 @@ RUN mkdir -p /usr/local/autodba/share/collector && \
     mv pganalyze-collector-setup collector-setup
 
 
+FROM go_builder as collector_api_server_builder
+RUN mkdir -p /usr/local/autodba/share/collector_api_server
+COPY collector-api/ /usr/local/autodba/share/collector_api_server/
+RUN cd /usr/local/autodba/share/collector_api_server/ && \
+    go build -o collector-api-server ./cmd/server/main.go
+
 FROM go_builder as bff_builder
 # Build bff
 WORKDIR /home/autodba/bff
@@ -85,6 +91,7 @@ FROM base AS builder
 COPY --from=solid_builder /home/autodba/solid/dist /usr/local/autodba/share/webapp
 COPY --from=rdsexporter_builder /usr/local/autodba/share/prometheus_exporters/rds_exporter /usr/local/autodba/share/prometheus_exporters/rds_exporter
 COPY --from=collector_builder /usr/local/autodba/share/collector /usr/local/autodba/share/collector
+COPY --from=collector_api_server_builder  /usr/local/autodba/share/collector_api_server /usr/local/autodba/share/collector_api_server
 COPY --from=bff_builder /usr/local/autodba/bin/autodba-bff /usr/local/autodba/bin/autodba-bff
 COPY --from=bff_builder /home/autodba/bff/config.json /usr/local/autodba/config/autodba/config.json
 COPY entrypoint.sh /usr/local/autodba/bin/autodba-entrypoint.sh
@@ -148,6 +155,7 @@ RUN mkdir -p /usr/local/autodba/share/prometheus_exporters/postgres_exporter && 
 COPY --from=builder /usr/local/autodba/bin /usr/local/autodba/bin
 COPY --from=builder /usr/local/autodba/share/webapp /usr/local/autodba/share/webapp
 COPY --from=builder /usr/local/autodba/share/collector /usr/local/autodba/share/collector
+COPY --from=builder /usr/local/autodba/share/collector_api_server /usr/local/autodba/share/collector_api_server
 COPY --from=builder /usr/local/autodba/share/prometheus_exporters /usr/local/autodba/share/prometheus_exporters
 COPY --from=builder /usr/local/autodba/config/autodba/config.json /usr/local/autodba/config/autodba/config.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,14 +107,20 @@ RUN ./scripts/build.sh && \
     mv build_output/tar.gz/autodba-*.tar.gz release_output/  && \
     rm -rf build_output
 
-FROM bff_builder AS test
+FROM go_builder AS test
 WORKDIR /home/autodba/bff
+COPY bff/go.mod bff/go.sum ./
+RUN go mod download
+COPY bff/ ./
 RUN go test ./pkg/server/promql_codegen_test.go -v
 RUN go test ./pkg/server -v
 RUN go test ./pkg/metrics -v
 RUN go test ./pkg/prometheus -v
 
 WORKDIR /home/autodba/collector-api
+COPY collector-api/go.mod collector-api/go.sum ./
+RUN go mod download
+COPY collector-api/ ./
 RUN go test -v ./...
 
 FROM base AS autodba

--- a/collector-api/cmd/server/main.go
+++ b/collector-api/cmd/server/main.go
@@ -4,16 +4,23 @@ import (
 	"collector-api/internal/api"
 	"collector-api/internal/config"
 	"collector-api/internal/db"
+	"collector-api/internal/storage"
 	"fmt"
 	"log"
 	"net/http"
 )
 
 func main() {
-	// Load the configuration
+	// Load the configuration from the global config path
 	cfg, err := config.LoadConfigWithDefaultPath()
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// Ensure the required storage directories exist
+	err = storage.EnsureStorageDirectories(cfg.StorageDir)
+	if err != nil {
+		log.Fatalf("Failed to create storage directories: %v", err)
 	}
 
 	// Initialize the SQLite database

--- a/collector-api/cmd/server/main.go
+++ b/collector-api/cmd/server/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"collector-api/internal/api"
+	"collector-api/internal/config"
+	"collector-api/internal/db"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	// Load the configuration
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// Initialize the SQLite database
+	db.InitDB(cfg.DBPath)
+
+	// Setup routes and handlers, passing the configuration
+	router := api.SetupRoutes(cfg)
+
+	// Start the HTTP server
+	address := fmt.Sprintf("%s:%d", cfg.ServerHost, cfg.ServerPort)
+	log.Printf("Server starting on %s", address)
+	if err := http.ListenAndServe(address, router); err != nil {
+		log.Fatalf("Error starting server: %v", err)
+	}
+}

--- a/collector-api/cmd/server/main.go
+++ b/collector-api/cmd/server/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	// Load the configuration
-	cfg, err := config.LoadConfig()
+	cfg, err := config.LoadConfigWithDefaultPath()
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}

--- a/collector-api/collector-api-config.json
+++ b/collector-api/collector-api-config.json
@@ -1,7 +1,7 @@
 {
     "server_host": "0.0.0.0",
     "server_port": 7080,
-    "db_path": "./pganalyze.db",
+    "db_path": "./crystaldb-collector.db",
     "storage_dir": "./storage/",
     "api_key": "your-secure-api-key",
     "debug": true

--- a/collector-api/collector-api-config.json
+++ b/collector-api/collector-api-config.json
@@ -1,6 +1,6 @@
 {
     "server_host": "0.0.0.0",
-    "server_port": 8080,
+    "server_port": 7080,
     "db_path": "./pganalyze.db",
     "storage_dir": "./storage/",
     "api_key": "your-secure-api-key",

--- a/collector-api/collector-api-config.json
+++ b/collector-api/collector-api-config.json
@@ -1,0 +1,8 @@
+{
+    "server_host": "0.0.0.0",
+    "server_port": 8080,
+    "db_path": "./pganalyze.db",
+    "storage_dir": "./storage/",
+    "api_key": "your-secure-api-key",
+    "debug": true
+}

--- a/collector-api/go.mod
+++ b/collector-api/go.mod
@@ -5,4 +5,11 @@ go 1.21.6
 require (
 	github.com/gorilla/mux v1.8.0 // This is for routing
 	github.com/mattn/go-sqlite3 v1.14.7 // This is the SQLite driver
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/collector-api/go.mod
+++ b/collector-api/go.mod
@@ -1,0 +1,8 @@
+module collector-api
+
+go 1.21.6
+
+require (
+	github.com/gorilla/mux v1.8.0 // This is for routing
+	github.com/mattn/go-sqlite3 v1.14.7 // This is the SQLite driver
+)

--- a/collector-api/go.sum
+++ b/collector-api/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
+github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=

--- a/collector-api/go.sum
+++ b/collector-api/go.sum
@@ -1,4 +1,13 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
 github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/collector-api/internal/api/grant.go
+++ b/collector-api/internal/api/grant.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"collector-api/internal/auth"
+	"collector-api/internal/storage"
+	"collector-api/pkg/models"
+	"encoding/json"
+	"net/http"
+)
+
+func GrantHandler(w http.ResponseWriter, r *http.Request) {
+	// Authenticate the request
+	if !auth.Authenticate(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Generate a local directory grant for Phase 1
+	grant := models.Grant{
+		Valid:    true,
+		LocalDir: storage.GetLocalStorageDir(),
+	}
+
+	// Respond with the grant
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(grant)
+}

--- a/collector-api/internal/api/grant.go
+++ b/collector-api/internal/api/grant.go
@@ -34,10 +34,27 @@ func GrantHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Authenticated request from %s", r.RemoteAddr)
 	}
 
-	// Respond with the Grant storage subdirectory
+	// Populate GrantConfig with dummy data (replace this with actual server config)
+	grantConfig := models.GrantConfig{
+		ServerID:         "pgServer1",
+		ServerURL:        "http://localhost:7080",
+		SentryDsn:        "",
+		EnableActivity:   true,
+		EnableLogs:       false,
+		SchemaTableLimit: 0,
+		Features: models.GrantFeatures{
+			Logs:                        false,
+			StatementResetFrequency:     0,
+			StatementTimeoutMs:          0,
+			StatementTimeoutMsQueryText: 0,
+		},
+	}
+
+	// Respond with the Snapshot grant
 	grant := models.Grant{
 		Valid:    true,
-		LocalDir: storage.GetLocalStorageDir(), // Use the grants subdirectory
+		Config:   grantConfig,
+		LocalDir: storage.GetLocalStorageDir(),
 		S3URL:    "",
 	}
 

--- a/collector-api/internal/api/grant_logs.go
+++ b/collector-api/internal/api/grant_logs.go
@@ -8,9 +8,10 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"path/filepath"
 )
 
-func GrantHandler(w http.ResponseWriter, r *http.Request) {
+func GrantLogsHandler(w http.ResponseWriter, r *http.Request) {
 	// Load configuration
 	cfg, err := config.LoadConfigWithDefaultPath()
 	if err != nil {
@@ -31,27 +32,33 @@ func GrantHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cfg.Debug {
-		log.Printf("Authenticated request from %s", r.RemoteAddr)
+		log.Printf("Authenticated request for logs grant from %s", r.RemoteAddr)
 	}
 
-	// Respond with the Grant storage subdirectory
-	grant := models.Grant{
+	// Define the logs subdirectory dynamically
+	logsDir := filepath.Join(storage.GetLocalStorageDir(), "logs")
+
+	if cfg.Debug {
+		log.Printf("Logs directory resolved to: %s", logsDir)
+	}
+
+	// Respond with the Logs storage subdirectory
+	grantLogs := models.GrantLogs{
 		Valid:    true,
-		LocalDir: storage.GetLocalStorageDir(), // Use the grants subdirectory
-		S3URL:    "",
+		LocalDir: logsDir, // Use the logs subdirectory
 	}
 
-	// Respond with the grant
+	// Respond with the logs grant
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(grant); err != nil {
+	if err := json.NewEncoder(w).Encode(grantLogs); err != nil {
 		if cfg.Debug {
-			log.Printf("Error encoding grant response: %v", err)
+			log.Printf("Error encoding grant logs response: %v", err)
 		}
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return
 	}
 
 	if cfg.Debug {
-		log.Printf("Grant response successfully sent to %s", r.RemoteAddr)
+		log.Printf("Logs grant response successfully sent to %s", r.RemoteAddr)
 	}
 }

--- a/collector-api/internal/api/grant_logs.go
+++ b/collector-api/internal/api/grant_logs.go
@@ -42,10 +42,31 @@ func GrantLogsHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Logs directory resolved to: %s", logsDir)
 	}
 
+	// Populate GrantConfig with dummy data (replace this with actual server config)
+	grantConfig := models.GrantConfig{
+		ServerID:         "pgServer1",
+		ServerURL:        "http://localhost:7080",
+		SentryDsn:        "",
+		EnableActivity:   true,
+		EnableLogs:       false,
+		SchemaTableLimit: 0,
+		Features: models.GrantFeatures{
+			Logs:                        false,
+			StatementResetFrequency:     0,
+			StatementTimeoutMs:          0,
+			StatementTimeoutMsQueryText: 0,
+		},
+	}
+
 	// Respond with the Logs storage subdirectory
 	grantLogs := models.GrantLogs{
-		Valid:    true,
-		LocalDir: logsDir, // Use the logs subdirectory
+		Valid:  false,
+		Config: grantConfig,
+		EncryptionKey: models.GrantLogsEncryptionKey{
+			CiphertextBlob: "",
+			KeyId:          "",
+			Plaintext:      "",
+		},
 	}
 
 	// Respond with the logs grant

--- a/collector-api/internal/api/middleware.go
+++ b/collector-api/internal/api/middleware.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+)
+
+// LoggingMiddleware logs all incoming HTTP requests if debugging is enabled
+func LoggingMiddleware(next http.Handler, debug bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if debug {
+			start := time.Now()
+
+			// Log the incoming request details
+			log.Printf("Started %s %s %s", r.Method, r.RequestURI, r.RemoteAddr)
+
+			// Log headers
+			for name, values := range r.Header {
+				for _, value := range values {
+					log.Printf("Header: %s = %s", name, value)
+				}
+			}
+
+			// Log request body if it's a JSON request
+			if r.Header.Get("Content-Type") == "application/json" {
+				body, err := ioutil.ReadAll(r.Body)
+				if err == nil {
+					log.Printf("Request Body: %s", string(body))
+
+					// Reset the body so it can be read again in the handler
+					r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+				} else {
+					log.Printf("Error reading body: %v", err)
+				}
+			}
+
+			// Call the next handler in the chain
+			next.ServeHTTP(w, r)
+
+			// Log the request completion
+			log.Printf("Completed in %v", time.Since(start))
+		} else {
+			// If debug is false, skip logging and just call the next handler
+			next.ServeHTTP(w, r)
+		}
+	})
+}

--- a/collector-api/internal/api/middleware_test.go
+++ b/collector-api/internal/api/middleware_test.go
@@ -1,0 +1,54 @@
+package api_test
+
+import (
+	"collector-api/internal/api"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggingMiddleware_DebugEnabled(t *testing.T) {
+	// Create a test handler
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap the handler with the LoggingMiddleware with debug enabled
+	debug := true
+	testServer := httptest.NewServer(api.LoggingMiddleware(handler, debug))
+	defer testServer.Close()
+
+	// Make a test request
+	resp, err := http.Get(testServer.URL)
+	if err != nil {
+		t.Fatalf("Failed to make test request: %v", err)
+	}
+
+	// Ensure the response is OK
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoggingMiddleware_DebugDisabled(t *testing.T) {
+	// Create a test handler
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap the handler with the LoggingMiddleware with debug disabled
+	debug := false
+	testServer := httptest.NewServer(api.LoggingMiddleware(handler, debug))
+	defer testServer.Close()
+
+	// Make a test request
+	resp, err := http.Get(testServer.URL)
+	if err != nil {
+		t.Fatalf("Failed to make test request: %v", err)
+	}
+
+	// Ensure the response is OK
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}

--- a/collector-api/internal/api/routes.go
+++ b/collector-api/internal/api/routes.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"collector-api/internal/config"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// SetupRoutes defines the API routes and attaches the middleware
+func SetupRoutes(cfg *config.Config) *mux.Router {
+	router := mux.NewRouter()
+
+	// Attach the logging middleware, passing the debug flag from the config
+	router.Use(func(next http.Handler) http.Handler {
+		return LoggingMiddleware(next, cfg.Debug)
+	})
+
+	// Define the routes
+	router.HandleFunc("/v2/snapshots/grant", GrantHandler).Methods("GET")
+	router.HandleFunc("/v2/snapshots", SubmitSnapshotHandler).Methods("POST")
+	router.HandleFunc("/v2/snapshots/compact", SubmitCompactSnapshotHandler).Methods("POST")
+
+	return router
+}

--- a/collector-api/internal/api/routes.go
+++ b/collector-api/internal/api/routes.go
@@ -18,6 +18,7 @@ func SetupRoutes(cfg *config.Config) *mux.Router {
 
 	// Define the routes
 	router.HandleFunc("/v2/snapshots/grant", GrantHandler).Methods("GET")
+	router.HandleFunc("/v2/snapshots/grant_logs", GrantLogsHandler).Methods("GET")
 	router.HandleFunc("/v2/snapshots", SubmitSnapshotHandler).Methods("POST")
 	router.HandleFunc("/v2/snapshots/compact", SubmitCompactSnapshotHandler).Methods("POST")
 

--- a/collector-api/internal/api/routes.go
+++ b/collector-api/internal/api/routes.go
@@ -19,8 +19,8 @@ func SetupRoutes(cfg *config.Config) *mux.Router {
 	// Define the routes
 	router.HandleFunc("/v2/snapshots/grant", GrantHandler).Methods("GET")
 	router.HandleFunc("/v2/snapshots/grant_logs", GrantLogsHandler).Methods("GET")
-	router.HandleFunc("/v2/snapshots", SubmitSnapshotHandler).Methods("POST")
-	router.HandleFunc("/v2/snapshots/compact", SubmitCompactSnapshotHandler).Methods("POST")
+	router.HandleFunc("/v2/snapshots", SnapshotHandler).Methods("POST")
+	router.HandleFunc("/v2/snapshots/compact", CompactSnapshotHandler).Methods("POST")
 
 	return router
 }

--- a/collector-api/internal/api/snapshots.go
+++ b/collector-api/internal/api/snapshots.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"collector-api/internal/auth"
+	"collector-api/internal/db"
+	"collector-api/internal/storage"
+	"collector-api/pkg/models"
+	"encoding/json"
+	"net/http"
+)
+
+func SubmitSnapshotHandler(w http.ResponseWriter, r *http.Request) {
+	if !auth.Authenticate(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var snapshot models.Snapshot
+	err := json.NewDecoder(r.Body).Decode(&snapshot)
+	if err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	// Store the snapshot metadata
+	err = db.StoreSnapshotMetadata(snapshot)
+	if err != nil {
+		http.Error(w, "Error storing snapshot", http.StatusInternalServerError)
+		return
+	}
+
+	// Move the snapshot to local storage
+	err = storage.StoreSnapshot(snapshot)
+	if err != nil {
+		http.Error(w, "Error storing snapshot data", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func SubmitCompactSnapshotHandler(w http.ResponseWriter, r *http.Request) {
+	if !auth.Authenticate(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var snapshot models.CompactSnapshot
+	err := json.NewDecoder(r.Body).Decode(&snapshot)
+	if err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	// Store the compact snapshot metadata
+	err = db.StoreCompactSnapshotMetadata(snapshot)
+	if err != nil {
+		http.Error(w, "Error storing compact snapshot", http.StatusInternalServerError)
+		return
+	}
+
+	// Move the compact snapshot to local storage
+	err = storage.StoreCompactSnapshot(snapshot)
+	if err != nil {
+		http.Error(w, "Error storing compact snapshot data", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/collector-api/internal/api/snapshots.go
+++ b/collector-api/internal/api/snapshots.go
@@ -2,69 +2,198 @@ package api
 
 import (
 	"collector-api/internal/auth"
+	"collector-api/internal/config"
 	"collector-api/internal/db"
-	"collector-api/internal/storage"
 	"collector-api/pkg/models"
-	"encoding/json"
+	"fmt"
+	"log"
 	"net/http"
+	"strconv"
 )
 
-func SubmitSnapshotHandler(w http.ResponseWriter, r *http.Request) {
+func SnapshotHandler(w http.ResponseWriter, r *http.Request) {
+	// Load configuration
+	cfg, err := config.LoadConfigWithDefaultPath()
+	if err != nil {
+		http.Error(w, "Failed to load config", http.StatusInternalServerError)
+		if cfg.Debug {
+			log.Printf("Error loading config: %v", err)
+		}
+		return
+	}
+
+	// Authenticate the request
 	if !auth.Authenticate(r) {
+		if cfg.Debug {
+			log.Printf("Unauthorized access attempt from %s", r.RemoteAddr)
+		}
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	var snapshot models.Snapshot
-	err := json.NewDecoder(r.Body).Decode(&snapshot)
-	if err != nil {
+	if cfg.Debug {
+		log.Printf("Authenticated request for snapshot submission from %s", r.RemoteAddr)
+	}
+
+	// Parse form data
+	if err := r.ParseForm(); err != nil {
+		if cfg.Debug {
+			log.Printf("Error parsing form data: %v", err)
+		}
 		http.Error(w, "Invalid request payload", http.StatusBadRequest)
 		return
 	}
 
+	// Retrieve form values
+	s3Location := r.FormValue("s3_location")
+	collectedAtStr := r.FormValue("collected_at")
+
+	// Validate the required fields
+	if s3Location == "" || collectedAtStr == "" {
+		if cfg.Debug {
+			log.Printf("Missing required form values: s3_location or collected_at")
+		}
+		http.Error(w, "Missing required parameters", http.StatusBadRequest)
+		return
+	}
+
+	// Parse collectedAt as an int64
+	collectedAt, err := strconv.ParseInt(collectedAtStr, 10, 64)
+	if err != nil {
+		if cfg.Debug {
+			log.Printf("Invalid collected_at value: %s", collectedAtStr)
+		}
+		http.Error(w, "Invalid collected_at value", http.StatusBadRequest)
+		return
+	}
+
+	if cfg.Debug {
+		log.Printf("Received snapshot submission: s3_location=%s, collected_at=%d", s3Location, collectedAt)
+	}
+
 	// Store the snapshot metadata
+	snapshot := models.Snapshot{
+		S3Location:  s3Location,
+		CollectedAt: collectedAt,
+	}
 	err = db.StoreSnapshotMetadata(snapshot)
 	if err != nil {
 		http.Error(w, "Error storing snapshot", http.StatusInternalServerError)
 		return
 	}
 
-	// Move the snapshot to local storage
-	err = storage.StoreSnapshot(snapshot)
+	// Simulate handling the snapshot submission (replace with actual logic)
+	err = handleFullSnapshot(s3Location, collectedAt)
 	if err != nil {
-		http.Error(w, "Error storing snapshot data", http.StatusInternalServerError)
+		if cfg.Debug {
+			log.Printf("Error handling snapshot submission: %v", err)
+		}
+		http.Error(w, "Failed to handle snapshot submission", http.StatusInternalServerError)
 		return
 	}
 
+	// Respond with success
 	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "Snapshot successfully processed")
 }
 
-func SubmitCompactSnapshotHandler(w http.ResponseWriter, r *http.Request) {
+// Dummy function for handling the snapshot submission
+func handleFullSnapshot(s3Location string, collectedAt int64) error {
+	// Here, implement your actual logic for processing the snapshot
+	// e.g., saving to local storage, uploading to S3, etc.
+	log.Printf("Processing full snapshot submission with s3_location: %s and collected_at: %d", s3Location, collectedAt)
+	return nil
+}
+
+func CompactSnapshotHandler(w http.ResponseWriter, r *http.Request) {
+	// Load configuration
+	cfg, err := config.LoadConfigWithDefaultPath()
+	if err != nil {
+		http.Error(w, "Failed to load config", http.StatusInternalServerError)
+		if cfg.Debug {
+			log.Printf("Error loading config: %v", err)
+		}
+		return
+	}
+
+	// Authenticate the request
 	if !auth.Authenticate(r) {
+		if cfg.Debug {
+			log.Printf("Unauthorized access attempt from %s", r.RemoteAddr)
+		}
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
-	var snapshot models.CompactSnapshot
-	err := json.NewDecoder(r.Body).Decode(&snapshot)
-	if err != nil {
+	if cfg.Debug {
+		log.Printf("Authenticated request for compact snapshot from %s", r.RemoteAddr)
+	}
+
+	// Parse form data
+	if err := r.ParseForm(); err != nil {
+		if cfg.Debug {
+			log.Printf("Error parsing form data: %v", err)
+		}
 		http.Error(w, "Invalid request payload", http.StatusBadRequest)
 		return
 	}
 
-	// Store the compact snapshot metadata
+	// Retrieve form values
+	s3Location := r.FormValue("s3_location")
+	collectedAtStr := r.FormValue("collected_at")
+
+	if s3Location == "" || collectedAtStr == "" {
+		if cfg.Debug {
+			log.Printf("Missing required form values: s3_location or collected_at")
+		}
+		http.Error(w, "Missing required parameters", http.StatusBadRequest)
+		return
+	}
+
+	// Parse collectedAt as an int64
+	collectedAt, err := strconv.ParseInt(collectedAtStr, 10, 64)
+	if err != nil {
+		if cfg.Debug {
+			log.Printf("Invalid collected_at value: %s", collectedAtStr)
+		}
+		http.Error(w, "Invalid collected_at value", http.StatusBadRequest)
+		return
+	}
+
+	if cfg.Debug {
+		log.Printf("Received compact snapshot: s3_location=%s, collected_at=%d", s3Location, collectedAt)
+	}
+
+	// Store the snapshot metadata
+	snapshot := models.CompactSnapshot{
+		S3Location:  s3Location,
+		CollectedAt: collectedAt,
+	}
 	err = db.StoreCompactSnapshotMetadata(snapshot)
 	if err != nil {
 		http.Error(w, "Error storing compact snapshot", http.StatusInternalServerError)
 		return
 	}
 
-	// Move the compact snapshot to local storage
-	err = storage.StoreCompactSnapshot(snapshot)
+	// Simulate handling the compact snapshot (you'll replace this with your actual logic)
+	err = handleCompactSnapshot(s3Location, collectedAt)
 	if err != nil {
-		http.Error(w, "Error storing compact snapshot data", http.StatusInternalServerError)
+		if cfg.Debug {
+			log.Printf("Error handling compact snapshot: %v", err)
+		}
+		http.Error(w, "Failed to handle compact snapshot", http.StatusInternalServerError)
 		return
 	}
 
+	// Respond with success
 	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "Compact snapshot successfully processed")
+}
+
+// Dummy function for handling the compact snapshot
+func handleCompactSnapshot(s3Location string, collectedAt int64) error {
+	// Here, implement your actual logic for processing the compact snapshot
+	// e.g., saving to local storage, uploading to S3, etc.
+	log.Printf("Processing compact snapshot with s3_location: %s and collected_at: %d", s3Location, collectedAt)
+	return nil
 }

--- a/collector-api/internal/auth/auth.go
+++ b/collector-api/internal/auth/auth.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Authenticate(r *http.Request) bool {
-	cfg, _ := config.LoadConfig()
+	cfg, _ := config.LoadConfigWithDefaultPath()
 	apiKey := r.Header.Get("Pganalyze-Api-Key")
 	return apiKey == cfg.APIKey
 }

--- a/collector-api/internal/auth/auth.go
+++ b/collector-api/internal/auth/auth.go
@@ -1,0 +1,12 @@
+package auth
+
+import (
+	"collector-api/internal/config"
+	"net/http"
+)
+
+func Authenticate(r *http.Request) bool {
+	cfg, _ := config.LoadConfig()
+	apiKey := r.Header.Get("Pganalyze-Api-Key")
+	return apiKey == cfg.APIKey
+}

--- a/collector-api/internal/config/config.go
+++ b/collector-api/internal/config/config.go
@@ -11,18 +11,16 @@ var globalConfigPath string = "collector-api-config.json" // Default config path
 type Config struct {
 	ServerHost string `json:"server_host"`
 	ServerPort int    `json:"server_port"`
-	DBPath     string `json:"db_path"` // Path to SQLite database file
-	StorageDir string `json:"storage_dir"`
+	DBPath     string `json:"db_path"`     // Path to SQLite database file
+	StorageDir string `json:"storage_dir"` // Base storage directory
 	APIKey     string `json:"api_key"`
 	Debug      bool   `json:"debug"` // Enable or disable debug logging
 }
 
-// LoadConfig loads the configuration from the provided file path
 func LoadConfig(configPath string) (*Config, error) {
 	file, err := os.Open(configPath)
 	if err != nil {
-		x, _ := os.Getwd()
-		log.Fatalf("Could not open config file: %v in %v", err, x)
+		log.Fatalf("Could not open config file: %v", err)
 		return nil, err
 	}
 	defer file.Close()

--- a/collector-api/internal/config/config.go
+++ b/collector-api/internal/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+)
+
+type Config struct {
+	ServerHost string `json:"server_host"`
+	ServerPort int    `json:"server_port"`
+	DBPath     string `json:"db_path"` // Path to SQLite database file
+	StorageDir string `json:"storage_dir"`
+	APIKey     string `json:"api_key"`
+	Debug      bool   `json:"debug"` // Enable or disable debug logging
+}
+
+func LoadConfig() (*Config, error) {
+	file, err := os.Open("collector-api-config.json")
+	if err != nil {
+		log.Fatalf("Could not open config file: %v", err)
+		return nil, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	config := Config{}
+	err = decoder.Decode(&config)
+	if err != nil {
+		log.Fatalf("Could not decode config JSON: %v", err)
+		return nil, err
+	}
+	return &config, nil
+}

--- a/collector-api/internal/config/config.go
+++ b/collector-api/internal/config/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 )
 
+var globalConfigPath string = "collector-api-config.json" // Default config path
+
 type Config struct {
 	ServerHost string `json:"server_host"`
 	ServerPort int    `json:"server_port"`
@@ -15,10 +17,12 @@ type Config struct {
 	Debug      bool   `json:"debug"` // Enable or disable debug logging
 }
 
-func LoadConfig() (*Config, error) {
-	file, err := os.Open("collector-api-config.json")
+// LoadConfig loads the configuration from the provided file path
+func LoadConfig(configPath string) (*Config, error) {
+	file, err := os.Open(configPath)
 	if err != nil {
-		log.Fatalf("Could not open config file: %v", err)
+		x, _ := os.Getwd()
+		log.Fatalf("Could not open config file: %v in %v", err, x)
 		return nil, err
 	}
 	defer file.Close()
@@ -31,4 +35,14 @@ func LoadConfig() (*Config, error) {
 		return nil, err
 	}
 	return &config, nil
+}
+
+// LoadConfigWithDefaultPath loads the config from the globalConfigPath if no path is provided
+func LoadConfigWithDefaultPath() (*Config, error) {
+	return LoadConfig(globalConfigPath)
+}
+
+// SetGlobalConfigPath allows setting the global config path at application startup
+func SetGlobalConfigPath(configPath string) {
+	globalConfigPath = configPath
 }

--- a/collector-api/internal/config/config_test.go
+++ b/collector-api/internal/config/config_test.go
@@ -1,0 +1,45 @@
+package config_test
+
+import (
+	"collector-api/internal/config"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig(t *testing.T) {
+	// Create a mock config.json for testing
+	configFile := `{
+		"server_host": "127.0.0.1",
+		"server_port": 8080,
+		"db_path": "./test.db",
+		"storage_dir": "./storage",
+		"api_key": "test-api-key",
+		"debug": true
+	}`
+
+	// Write to a temporary file
+	tmpFile, err := os.CreateTemp("", "config.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name()) // Clean up the file after the test
+
+	// Write the mock config to the temp file
+	if _, err := tmpFile.Write([]byte(configFile)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load the config from the temp file
+	cfg, err := config.LoadConfig(tmpFile.Name())
+
+	// Assert no error occurred and values are correct
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", cfg.ServerHost)
+	assert.Equal(t, 8080, cfg.ServerPort)
+	assert.Equal(t, "./test.db", cfg.DBPath)
+	assert.Equal(t, "./storage", cfg.StorageDir)
+	assert.Equal(t, "test-api-key", cfg.APIKey)
+	assert.True(t, cfg.Debug)
+}

--- a/collector-api/internal/db/db.go
+++ b/collector-api/internal/db/db.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"collector-api/pkg/models"
+	"database/sql"
+	"log"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver
+)
+
+var db *sql.DB
+
+func InitDB(dbPath string) {
+	var err error
+
+	// Create the SQLite database file if it doesn't exist
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		file, err := os.Create(dbPath)
+		if err != nil {
+			log.Fatalf("Failed to create database file: %v", err)
+		}
+		file.Close()
+	}
+
+	// Open the SQLite database
+	db, err = sql.Open("sqlite3", dbPath)
+	if err != nil {
+		log.Fatalf("Failed to connect to SQLite database: %v", err)
+	}
+
+	// Initialize database schema
+	initSchema()
+}
+
+func initSchema() {
+	// Create the necessary tables for snapshots
+	createSnapshotTable := `
+	CREATE TABLE IF NOT EXISTS snapshots (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		collected_at INTEGER,
+		local_dir TEXT,
+		status TEXT
+	);`
+
+	createCompactSnapshotTable := `
+	CREATE TABLE IF NOT EXISTS compact_snapshots (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		collected_at INTEGER,
+		local_dir TEXT,
+		snapshot_type TEXT
+	);`
+
+	_, err := db.Exec(createSnapshotTable)
+	if err != nil {
+		log.Fatalf("Error creating snapshots table: %v", err)
+	}
+
+	_, err = db.Exec(createCompactSnapshotTable)
+	if err != nil {
+		log.Fatalf("Error creating compact_snapshots table: %v", err)
+	}
+}
+
+func StoreSnapshotMetadata(snapshot models.Snapshot) error {
+	// Insert metadata into the SQLite database
+	_, err := db.Exec(`
+		INSERT INTO snapshots (collected_at, local_dir, status)
+		VALUES (?, ?, ?)`,
+		snapshot.CollectedAt, snapshot.LocalDir, snapshot.Status)
+	return err
+}
+
+func StoreCompactSnapshotMetadata(snapshot models.CompactSnapshot) error {
+	// Insert compact snapshot metadata
+	_, err := db.Exec(`
+		INSERT INTO compact_snapshots (collected_at, local_dir, snapshot_type)
+		VALUES (?, ?, ?)`,
+		snapshot.CollectedAt, snapshot.LocalDir, snapshot.Type)
+	return err
+}

--- a/collector-api/internal/db/db.go
+++ b/collector-api/internal/db/db.go
@@ -39,16 +39,14 @@ func initSchema() {
 	CREATE TABLE IF NOT EXISTS snapshots (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		collected_at INTEGER,
-		local_dir TEXT,
-		status TEXT
+		s3_location TEXT
 	);`
 
 	createCompactSnapshotTable := `
 	CREATE TABLE IF NOT EXISTS compact_snapshots (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		collected_at INTEGER,
-		local_dir TEXT,
-		snapshot_type TEXT
+		s3_location TEXT
 	);`
 
 	_, err := db.Exec(createSnapshotTable)
@@ -65,17 +63,17 @@ func initSchema() {
 func StoreSnapshotMetadata(snapshot models.Snapshot) error {
 	// Insert metadata into the SQLite database
 	_, err := db.Exec(`
-		INSERT INTO snapshots (collected_at, local_dir, status)
-		VALUES (?, ?, ?)`,
-		snapshot.CollectedAt, snapshot.LocalDir, snapshot.Status)
+		INSERT INTO snapshots (collected_at, s3_location)
+		VALUES (?, ?)`,
+		snapshot.CollectedAt, snapshot.S3Location)
 	return err
 }
 
 func StoreCompactSnapshotMetadata(snapshot models.CompactSnapshot) error {
 	// Insert compact snapshot metadata
 	_, err := db.Exec(`
-		INSERT INTO compact_snapshots (collected_at, local_dir, snapshot_type)
-		VALUES (?, ?, ?)`,
-		snapshot.CollectedAt, snapshot.LocalDir, snapshot.Type)
+		INSERT INTO compact_snapshots (collected_at, s3_location)
+		VALUES (?, ?)`,
+		snapshot.CollectedAt, snapshot.S3Location)
 	return err
 }

--- a/collector-api/internal/db/db_test.go
+++ b/collector-api/internal/db/db_test.go
@@ -1,0 +1,47 @@
+package db_test
+
+import (
+	"collector-api/internal/db"
+	"collector-api/pkg/models"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreSnapshotMetadata(t *testing.T) {
+	// Initialize in-memory SQLite database for testing
+	dbPath := ":memory:" // Use in-memory database for testing
+	db.InitDB(dbPath)
+
+	// Create a sample snapshot
+	snapshot := models.Snapshot{
+		CollectedAt: 1234567890,
+		LocalDir:    "/test/dir",
+		Status:      "completed",
+	}
+
+	// Store snapshot metadata
+	err := db.StoreSnapshotMetadata(snapshot)
+	assert.NoError(t, err)
+
+	// Check that snapshot was inserted (you can extend this with SELECT queries)
+}
+
+func TestStoreCompactSnapshotMetadata(t *testing.T) {
+	// Initialize in-memory SQLite database for testing
+	dbPath := ":memory:" // Use in-memory database for testing
+	db.InitDB(dbPath)
+
+	// Create a sample compact snapshot
+	snapshot := models.CompactSnapshot{
+		CollectedAt: 1234567890,
+		LocalDir:    "/test/dir",
+		Type:        "compact",
+	}
+
+	// Store compact snapshot metadata
+	err := db.StoreCompactSnapshotMetadata(snapshot)
+	assert.NoError(t, err)
+
+	// Check that compact snapshot was inserted (you can extend this with SELECT queries)
+}

--- a/collector-api/internal/db/db_test.go
+++ b/collector-api/internal/db/db_test.go
@@ -16,8 +16,7 @@ func TestStoreSnapshotMetadata(t *testing.T) {
 	// Create a sample snapshot
 	snapshot := models.Snapshot{
 		CollectedAt: 1234567890,
-		LocalDir:    "/test/dir",
-		Status:      "completed",
+		S3Location:  "/test/dir",
 	}
 
 	// Store snapshot metadata
@@ -35,8 +34,7 @@ func TestStoreCompactSnapshotMetadata(t *testing.T) {
 	// Create a sample compact snapshot
 	snapshot := models.CompactSnapshot{
 		CollectedAt: 1234567890,
-		LocalDir:    "/test/dir",
-		Type:        "compact",
+		S3Location:  "/test/dir",
 	}
 
 	// Store compact snapshot metadata

--- a/collector-api/internal/storage/local_storage.go
+++ b/collector-api/internal/storage/local_storage.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"collector-api/internal/config"
+	"collector-api/pkg/models"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// GetLocalStorageDir returns the directory for storing snapshot files
+func GetLocalStorageDir() string {
+	cfg, _ := config.LoadConfig()
+	return cfg.StorageDir
+}
+
+// StoreSnapshot stores a regular snapshot to the local directory
+func StoreSnapshot(snapshot models.Snapshot) error {
+	storageDir := GetLocalStorageDir()
+
+	// Create file path based on snapshot ID
+	filePath := filepath.Join(storageDir, fmt.Sprintf("snapshot-%d.json", snapshot.ID))
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Serialize and save the snapshot (pseudo-code)
+	// You need to serialize the snapshot as JSON or another format based on your needs
+	// err = json.NewEncoder(file).Encode(snapshot)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// StoreCompactSnapshot stores a compact snapshot to the local directory
+func StoreCompactSnapshot(snapshot models.CompactSnapshot) error {
+	storageDir := GetLocalStorageDir()
+
+	// Create file path based on compact snapshot ID
+	filePath := filepath.Join(storageDir, fmt.Sprintf("compact_snapshot-%d.json", snapshot.ID))
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Serialize and save the compact snapshot (pseudo-code)
+	// err = json.NewEncoder(file).Encode(snapshot)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/collector-api/internal/storage/local_storage.go
+++ b/collector-api/internal/storage/local_storage.go
@@ -10,7 +10,7 @@ import (
 
 // GetLocalStorageDir returns the directory for storing snapshot files
 func GetLocalStorageDir() string {
-	cfg, _ := config.LoadConfig()
+	cfg, _ := config.LoadConfigWithDefaultPath()
 	return cfg.StorageDir
 }
 

--- a/collector-api/internal/storage/local_storage.go
+++ b/collector-api/internal/storage/local_storage.go
@@ -3,7 +3,9 @@ package storage
 import (
 	"collector-api/internal/config"
 	"collector-api/pkg/models"
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -16,41 +18,101 @@ func GetLocalStorageDir() string {
 
 // StoreSnapshot stores a regular snapshot to the local directory
 func StoreSnapshot(snapshot models.Snapshot) error {
+	cfg, err := config.LoadConfigWithDefaultPath()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %v", err)
+	}
+
 	storageDir := GetLocalStorageDir()
 
 	// Create file path based on snapshot ID
 	filePath := filepath.Join(storageDir, fmt.Sprintf("snapshot-%d.json", snapshot.ID))
+
+	if cfg.Debug {
+		log.Printf("Storing snapshot: ID=%d, Path=%s", snapshot.ID, filePath)
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
+		if cfg.Debug {
+			log.Printf("Error creating file for snapshot: %v", err)
+		}
 		return err
 	}
 	defer file.Close()
 
-	// Serialize and save the snapshot (pseudo-code)
-	// You need to serialize the snapshot as JSON or another format based on your needs
-	// err = json.NewEncoder(file).Encode(snapshot)
-	if err != nil {
+	// Serialize and save the snapshot
+	if err := json.NewEncoder(file).Encode(snapshot); err != nil {
+		if cfg.Debug {
+			log.Printf("Error encoding snapshot: %v", err)
+		}
 		return err
 	}
+
+	if cfg.Debug {
+		log.Printf("Snapshot successfully stored at %s", filePath)
+	}
+
 	return nil
 }
 
 // StoreCompactSnapshot stores a compact snapshot to the local directory
 func StoreCompactSnapshot(snapshot models.CompactSnapshot) error {
+	cfg, err := config.LoadConfigWithDefaultPath()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %v", err)
+	}
+
 	storageDir := GetLocalStorageDir()
 
 	// Create file path based on compact snapshot ID
 	filePath := filepath.Join(storageDir, fmt.Sprintf("compact_snapshot-%d.json", snapshot.ID))
+
+	if cfg.Debug {
+		log.Printf("Storing compact snapshot: ID=%d, Path=%s", snapshot.ID, filePath)
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
+		if cfg.Debug {
+			log.Printf("Error creating file for compact snapshot: %v", err)
+		}
 		return err
 	}
 	defer file.Close()
 
-	// Serialize and save the compact snapshot (pseudo-code)
-	// err = json.NewEncoder(file).Encode(snapshot)
-	if err != nil {
+	// Serialize and save the compact snapshot
+	if err := json.NewEncoder(file).Encode(snapshot); err != nil {
+		if cfg.Debug {
+			log.Printf("Error encoding compact snapshot: %v", err)
+		}
 		return err
 	}
+
+	if cfg.Debug {
+		log.Printf("Compact snapshot successfully stored at %s", filePath)
+	}
+
+	return nil
+}
+
+// EnsureStorageDirectories ensures the required subdirectories exist under the base storage directory
+func EnsureStorageDirectories(baseDir string) error {
+	subdirs := []string{
+		baseDir,
+		filepath.Join(baseDir, "logs"),
+		filepath.Join(baseDir, "snapshots"),
+		filepath.Join(baseDir, "compact_snapshots"),
+	}
+
+	for _, subdir := range subdirs {
+		err := os.MkdirAll(subdir, os.ModePerm)
+		if err != nil {
+			log.Printf("Failed to create directory %s: %v", subdir, err)
+			return err
+		}
+		log.Printf("Created/verified storage directory: %s", subdir)
+	}
+
 	return nil
 }

--- a/collector-api/pkg/models/grant.go
+++ b/collector-api/pkg/models/grant.go
@@ -1,7 +1,31 @@
 package models
 
+// GrantConfig represents configuration settings for logs and snapshots
+type GrantConfig struct {
+	ServerID  string        `json:"server_id"`
+	ServerURL string        `json:"server_url"`
+	SentryDsn string        `json:"sentry_dsn"`
+	Features  GrantFeatures `json:"features"`
+
+	EnableActivity bool `json:"enable_activity"`
+	EnableLogs     bool `json:"enable_logs"`
+
+	SchemaTableLimit int `json:"schema_table_limit"` // Maximum number of tables that can be monitored per server
+}
+
+// GrantFeatures represents the features related to logs and statements
+type GrantFeatures struct {
+	Logs                        bool  `json:"logs"`
+	StatementResetFrequency     int   `json:"statement_reset_frequency"`
+	StatementTimeoutMs          int32 `json:"statement_timeout_ms"`
+	StatementTimeoutMsQueryText int32 `json:"statement_timeout_ms_query_text"`
+}
+
+// Grant represents the structure of the grant for accessing snapshots/logs
 type Grant struct {
-	Valid    bool   `json:"valid"`
-	LocalDir string `json:"local_dir"`
-	S3URL    string `json:"s3_url,omitempty"`
+	Valid    bool              `json:"valid"`
+	Config   GrantConfig       `json:"config"`
+	S3URL    string            `json:"s3_url"`
+	S3Fields map[string]string `json:"s3_fields"`
+	LocalDir string            `json:"local_dir"`
 }

--- a/collector-api/pkg/models/grant.go
+++ b/collector-api/pkg/models/grant.go
@@ -1,0 +1,7 @@
+package models
+
+type Grant struct {
+	Valid    bool   `json:"valid"`
+	LocalDir string `json:"local_dir"`
+	S3URL    string `json:"s3_url,omitempty"`
+}

--- a/collector-api/pkg/models/grant_logs.go
+++ b/collector-api/pkg/models/grant_logs.go
@@ -1,7 +1,24 @@
 package models
 
 // GrantLogs represents a grant for accessing log directories
+// GrantLogsEncryptionKey represents encryption details for logs
+type GrantLogsEncryptionKey struct {
+	CiphertextBlob string `json:"ciphertext_blob"`
+	KeyId          string `json:"key_id"`
+	Plaintext      string `json:"plaintext"`
+}
+
+// GrantS3 represents S3-related details for logs and snapshots
+type GrantS3 struct {
+	S3URL    string            `json:"s3_url"`
+	S3Fields map[string]string `json:"s3_fields"`
+}
+
+// GrantLogs represents the structure of the grant for log access
 type GrantLogs struct {
-	Valid    bool   `json:"valid"`
-	LocalDir string `json:"local_dir"`
+	Valid         bool                   `json:"valid"`
+	Config        GrantConfig            `json:"config"`
+	Logdata       GrantS3                `json:"logdata"`
+	Snapshot      GrantS3                `json:"snapshot"`
+	EncryptionKey GrantLogsEncryptionKey `json:"encryption_key"`
 }

--- a/collector-api/pkg/models/grant_logs.go
+++ b/collector-api/pkg/models/grant_logs.go
@@ -1,0 +1,7 @@
+package models
+
+// GrantLogs represents a grant for accessing log directories
+type GrantLogs struct {
+	Valid    bool   `json:"valid"`
+	LocalDir string `json:"local_dir"`
+}

--- a/collector-api/pkg/models/snapshot.go
+++ b/collector-api/pkg/models/snapshot.go
@@ -1,0 +1,15 @@
+package models
+
+type Snapshot struct {
+	ID          int64  `json:"id"`
+	CollectedAt int64  `json:"collected_at"`
+	LocalDir    string `json:"local_dir"`
+	Status      string `json:"status"`
+}
+
+type CompactSnapshot struct {
+	ID          int64  `json:"id"`
+	CollectedAt int64  `json:"collected_at"`
+	LocalDir    string `json:"local_dir"`
+	Type        string `json:"snapshot_type"`
+}

--- a/collector-api/pkg/models/snapshot.go
+++ b/collector-api/pkg/models/snapshot.go
@@ -3,13 +3,11 @@ package models
 type Snapshot struct {
 	ID          int64  `json:"id"`
 	CollectedAt int64  `json:"collected_at"`
-	LocalDir    string `json:"local_dir"`
-	Status      string `json:"status"`
+	S3Location  string `json:"local_dir"`
 }
 
 type CompactSnapshot struct {
 	ID          int64  `json:"id"`
 	CollectedAt int64  `json:"collected_at"`
-	LocalDir    string `json:"local_dir"`
-	Type        string `json:"snapshot_type"`
+	S3Location  string `json:"local_dir"`
 }

--- a/collector-api/scripts/run_local.sh
+++ b/collector-api/scripts/run_local.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd ${SCRIPT_DIR}/..
+
+# Start the server
+go run cmd/server/main.go

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,7 +138,7 @@ if [ -z "$DISABLE_DATA_COLLECTION" ] || [ "$DISABLE_DATA_COLLECTION" = false ]; 
     # Start up Collector
     if [ -f "$COLLECTOR_CONFIG_FILE" ]; then
       echo "Starting Collector..."
-      $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" --dry-run
+      $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" --statefile="$PARENT_DIR/share/collector/state" &
       COLLECTOR_COLLECTOR_PID=$!
     else
       echo "Collector configuration file not found, skipping Collector startup."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -122,19 +122,24 @@ if [ -z "$DISABLE_DATA_COLLECTION" ] || [ "$DISABLE_DATA_COLLECTION" = false ]; 
     echo "AWS environment variables are missing or empty, so not running the RDS Exporter."
   fi
 
-  echo "Starting Collector API Server..."
-  pushd "$PARENT_DIR/share/collector_api_server"
-  ./collector-api-server &
-  COLLECTOR_API_SERVER_PID=$!
-  popd
-  
-  # Start up Collector
-  if [ -f "$COLLECTOR_CONFIG_FILE" ]; then
+  # Check if collector_api_server exists before starting it. This acts as a feature-flag.
+  if [ -d "$PARENT_DIR/share/collector_api_server" ]; then
+    echo "Starting Collector API Server..."
+    pushd "$PARENT_DIR/share/collector_api_server"
+    ./collector-api-server &
+    COLLECTOR_API_SERVER_PID=$!
+    popd
+  else
+    echo "Warning: Skipping Collector API Server. Directory does not exist: $PARENT_DIR/share/collector_api_server"
+  fi
+
+  # Check if collector exists before starting it. This acts as a feature-flag.
+  if [ -d "$PARENT_DIR/share/collector" ]; then
     echo "Starting Collector..."
     $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" &
     COLLECTOR_PID=$!
   else
-    echo "Collector configuration file not found, skipping Collector startup."
+    echo "Warning: Skipping Collector. Directory does not exist: $PARENT_DIR/share/collector"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,7 +138,7 @@ if [ -z "$DISABLE_DATA_COLLECTION" ] || [ "$DISABLE_DATA_COLLECTION" = false ]; 
     # Start up Collector
     if [ -f "$COLLECTOR_CONFIG_FILE" ]; then
       echo "Starting Collector..."
-      $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" --statefile="$PARENT_DIR/share/collector/state" &
+      $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" --statefile="$PARENT_DIR/share/collector/state" --verbose &
       COLLECTOR_COLLECTOR_PID=$!
     else
       echo "Collector configuration file not found, skipping Collector startup."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,7 +136,7 @@ if [ -z "$DISABLE_DATA_COLLECTION" ] || [ "$DISABLE_DATA_COLLECTION" = false ]; 
   # Check if collector exists before starting it. This acts as a feature-flag.
   if [ -d "$PARENT_DIR/share/collector" ]; then
     echo "Starting Collector..."
-    $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" &
+    $PARENT_DIR/share/collector/collector --config="$COLLECTOR_CONFIG_FILE" --statefile="$PARENT_DIR/share/collector/state" &
     COLLECTOR_PID=$!
   else
     echo "Warning: Skipping Collector. Directory does not exist: $PARENT_DIR/share/collector"


### PR DESCRIPTION
This PR adds the stubs for a server that:
 - Provide `Grant`s to the Collector (to store the collected data in a local directory)
 - Accepts full and compact snapshot notifications

By running the Dockerfile, the Collector should start to work and store the protobuf binaries under `/usr/local/autodba/config/autodba/storage`.

Here are the steps to use the changes on this branch:
 - run the docker (e.g., via `./scripts/run.sh --db-url '<PG_CONN_STRING>' --rds-instance <RDS_INSTANCE_NAME>`)
 - Open a shell into the running docker: `docker exec -it $(docker ps | grep autodba-${USER}-1 | awk '{print $1}') /bin/bash`
    + The protobuf binaries are located under `/usr/local/autodba/config/autodba/storage`
    + You can see which binary is which by querying the sqlite3 database:
      * compact (activity) snapshots (every 10 seconds): `sqlite3 /usr/local/autodba/share/collector_api_server/crystaldb-collector.db "select * from compact_snapshots"`
      * full snapshots (every 10 minutes: `sqlite3 /usr/local/autodba/share/collector_api_server/crystaldb-collector.db "select * from snapshots"`