### PR TITLE
Update README to indicate PII filtering and resources needed for running AutoDBA

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Our near-term roadmap includes the following:
 - Observability
     - [x] Database and system metrics
     - [x] Wait events
-    - [ ] Query normalization + PII filtering
+    - [X] Query normalization + PII filtering
     - [ ] Log analysis
     - [ ] Fleet overview
 - Alerting

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ However, the following *temporary limitations* are presently in place:
 
 ### Prerequisites
 
-1. Linux server with network access to your PostgreSQL database
+1. Linux server with network access to your PostgreSQL database.
+We recommend using a machine with at least 2&nbsp;GB of RAM and 10&nbsp;GB of disk space (e.g., `t3.small` on AWS).
 2. A database user with access to read the metrics
 3. AWS credentials with permissions to read database metrics
 


### PR DESCRIPTION
- PII filtering and query normalization are in place
- Recommend using a Linux instance with at least 2 GB of memory and 10 GB of storage. These estimates will be refined in the future and extended to account for retention time.