### PR TITLE
DBA-351 Added recording rules to improve Prometheus queries

### DIFF
--- a/bff/cmd/generate_recording_rules/main.go
+++ b/bff/cmd/generate_recording_rules/main.go
@@ -1,0 +1,60 @@
+// Package main provides a command-line tool to generate Prometheus recording rules
+// from predefined metrics configurations.
+//
+// The tool takes an optional output path flag and generates a YAML configuration
+// file containing Prometheus recording rules. These rules are used to pre-compute
+// and save frequently-used or computationally-expensive queries.
+//
+// Usage:
+//
+//	go run main.go [-output path/to/output.yml]
+//
+// Flags:
+//
+//	-output: Specifies the output file path for the recording rules YAML
+//	        (default: "../prometheus/recording_rules.yml")
+//
+// The program will:
+// 1. Extract recording rules from the server package
+// 2. Generate a Prometheus-compatible YAML configuration
+// 3. Create the output directory if it doesn't exist
+// 4. Write the configuration to the specified file
+//
+// Exit codes:
+//
+//	0: Success
+//	1: Error (directory creation or file writing failed)
+package main
+
+import (
+	"flag"
+	"fmt"
+	"local/bff/pkg/server"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	outputPath := flag.String("output", "../prometheus/recording_rules.yml", "Output path for the recording rules YAML")
+	flag.Parse()
+
+	// Generate rules
+	rules := server.ExtractRecordingRules()
+	yamlConfig := server.GeneratePrometheusConfig(rules)
+
+	// Ensure directory exists
+	dir := filepath.Dir(*outputPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write to file
+	if err := os.WriteFile(*outputPath, []byte(yamlConfig), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Recording rules written to %s\n", *outputPath)
+	fmt.Printf("Generated %d rule groups\n", len(rules))
+}

--- a/bff/config.json
+++ b/bff/config.json
@@ -1,7 +1,7 @@
 {
   "port": "4000",
-  "time_dim_guard": 12,
-  "non_time_dim_guard": 3,
+  "time_dim_guard": 350,
+  "non_time_dim_guard": 350,
   "routes_config": {
     "/v1/health": {
       "params": [

--- a/bff/pkg/server/promql_codegen_ast.go
+++ b/bff/pkg/server/promql_codegen_ast.go
@@ -65,7 +65,7 @@ func (f *FunctionCall) String() string {
 	}
 	if f.TimeInterval != nil {
 		if f.TimeStep != nil {
-			return fmt.Sprintf(`%s(%s[%s:%s])`, f.Func, strings.Join(args, ", "), f.TimeInterval, f.TimeStep)
+			return fmt.Sprintf(`%s(%s[%s:%ss])`, f.Func, strings.Join(args, ", "), f.TimeInterval, f.TimeStep)
 		}
 		return fmt.Sprintf(`%s(%s[%s:])`, f.Func, strings.Join(args, ", "), f.TimeInterval)
 	}

--- a/bff/pkg/server/promql_codegen_test_cases.json
+++ b/bff/pkg/server/promql_codegen_test_cases.json
@@ -14,7 +14,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -32,7 +32,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"Lock:transactionid\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"Lock:transactionid\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -50,7 +50,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"CPU\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"CPU\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -68,7 +68,7 @@
       "offset": "2",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(usename, client_addr) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"} * on(usename) group_left() bottomk(3, topk(5, avg_over_time(sum by(usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10]))) \u003e bool 0)[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(usename, client_addr) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"} * on(usename) group_left() bottomk(3, topk(5, avg_over_time(sum by(usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10s]))) \u003e bool 0)[3600s:10s]))",
     "has_error": false
   },
   {
@@ -86,7 +86,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"Lock:transactionid|BufferPin:buffer_content\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"Lock:transactionid|BufferPin:buffer_content\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -122,7 +122,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(usename, client_addr) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"} * on(usename) group_left() topk(100, avg_over_time(sum by(usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10])) \u003e bool 0)[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(usename, client_addr) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"} * on(usename) group_left() topk(100, avg_over_time(sum by(usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10s])) \u003e bool 0)[3600s:10s]))",
     "has_error": false
   },
   {
@@ -140,7 +140,7 @@
       "offset": "5",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(usename, client_addr) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(usename, client_addr) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -194,7 +194,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(datname, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\",wait_event_name=~\"\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -212,7 +212,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(datname, client_addr) (cc_pg_stat_activity{datname=~\"db1\",query=~\"\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(datname, client_addr) (cc_pg_stat_activity{datname=~\"db1\",query=~\"\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10s]))",
     "has_error": false
   },
   {
@@ -230,7 +230,7 @@
       "offset": "",
       "dbidentifier": "a/b/c"
     },
-    "expected": "sort_desc(avg_over_time(sum by(query, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10]))",
+    "expected": "sort_desc(avg_over_time(sum by(query, usename) (cc_pg_stat_activity{datname=~\"db1\",sys_id=~\"b\",sys_scope=~\"c\",sys_type=~\"a\"})[3600s:10s]))",
     "has_error": false
   }
 ]

--- a/bff/pkg/server/recording_rules.go
+++ b/bff/pkg/server/recording_rules.go
@@ -1,0 +1,189 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RecordingRule represents a single Prometheus recording rule with a name and PromQL expression
+type RecordingRule struct {
+	Name string // The name of the recording rule
+	Expr string // The PromQL expression to be evaluated
+}
+
+// ValidDimensions returns all valid dimensions for activity queries
+// These dimensions are used to create different aggregation combinations
+func ValidDimensions() []string {
+	return []string{
+		"time",             // timestamp of the measurement
+		"datname",          // database name
+		"client_addr",      // client host address
+		"application_name", // name of the application
+		"backend_type",     // type of backend session
+		"query",            // SQL query being executed
+		"usename",          // database user name
+		"wait_event_name",  // name of the wait event if any
+	}
+}
+
+// TimeScenario defines a time window and recording interval
+type TimeScenario struct {
+	Duration string // Total time window to consider (e.g., "6h")
+	Step     string // Recording interval (e.g., "10m")
+}
+
+// Available time scenarios for recording rules
+// Currently only using 6h/10m, others are commented out but available if needed
+var timeScenarios = []TimeScenario{
+	{Duration: "6h", Step: "10m"},
+	// {Duration: "12h", Step: "30m"},
+	// {Duration: "24h", Step: "30m"},
+	// {Duration: "48h", Step: "30m"},
+	// {Duration: "168h", Step: "30m"},
+	// {Duration: "336h", Step: "60m"},
+}
+
+// RecordingRuleGroup represents a group of recording rules with the same interval
+type RecordingRuleGroup struct {
+	Name     string          // Name of the rule group
+	Interval string          // Recording interval for all rules in the group
+	Rules    []RecordingRule // List of recording rules in this group
+}
+
+// ExtractRecordingRules generates all necessary recording rules for PostgreSQL activity metrics
+// It creates two-dimensional aggregations for all valid dimension combinations
+func ExtractRecordingRules() []RecordingRuleGroup {
+	rulesByInterval := make(map[string][]RecordingRule)
+	seenQueries := make(map[string]bool) // Track unique queries to avoid duplicates
+	now := time.Now()
+
+	// Generate two-dimension aggregations for each time scenario
+	for _, scenario := range timeScenarios {
+		fmt.Printf(">>> scenario: %+v\n", scenario)
+		// Create interval suffix for rule naming (e.g., "_10m")
+		intervalSuffix := "_" + strings.ReplaceAll(scenario.Step, ".", "_")
+
+		// Base parameters for activity queries
+		baseParams := ActivityParams{
+			DbIdentifier: "a/b/c",
+			DatabaseList: "db1", // Dummy value for recording rules
+			Start:        "now-" + scenario.Duration,
+			End:          "now",
+			Step:         scenario.Step,
+		}
+
+		// Generate rules for each dimension combination
+		for _, dim := range ValidDimensions() {
+			for _, legend := range ValidDimensions() {
+				if legend == "time" {
+					continue // Skip time dimension as legend
+				}
+
+				params := baseParams
+				params.Dim = dim
+				params.Legend = legend
+
+				// Generate and process the PromQL query
+				input, err := extractPromQLInput(params, now)
+				if err != nil {
+					fmt.Printf(">>> error1: %v\n", err)
+					continue
+				}
+
+				query, err := GenerateStandardQuery(input)
+				fmt.Printf(">>> query: %s\n", query)
+				if err == nil && query != "" {
+					query = cleanupQueryForRecordingRule(query)
+					if !seenQueries[query] {
+						rulesByInterval[scenario.Step] = append(rulesByInterval[scenario.Step], RecordingRule{
+							Name: fmt.Sprintf("cc_pg_stat_activity:sum_by_%s__%s%s", dim, legend, intervalSuffix),
+							Expr: query,
+						})
+						seenQueries[query] = true
+					}
+				} else {
+					fmt.Printf(">>> error2: %v\n", err)
+				}
+			}
+		}
+	}
+
+	// Convert map to sorted slice of groups
+	var groups []RecordingRuleGroup
+	for interval, rules := range rulesByInterval {
+		groups = append(groups, RecordingRuleGroup{
+			Name:     fmt.Sprintf("activity_cube_recording_rules_%s", strings.ReplaceAll(interval, ".", "_")),
+			Interval: interval,
+			Rules:    rules,
+		})
+	}
+
+	// Sort groups by interval for consistent output
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Interval < groups[j].Interval
+	})
+
+	return groups
+}
+
+// cleanupQueryForRecordingRule sanitizes a PromQL query for use in recording rules
+// It removes specific filters and ensures proper dimension inclusion
+func cleanupQueryForRecordingRule(query string) string {
+	// Remove sort_desc wrapper if present
+	if strings.HasPrefix(query, "sort_desc(") {
+		query = strings.TrimPrefix(query, "sort_desc(")
+		query = strings.TrimSuffix(query, ")")
+	}
+
+	// Remove specific database and system filters while preserving structure
+	query = regexp.MustCompile(`\{[^}]*\}`).ReplaceAllStringFunc(query, func(match string) string {
+		patterns := []string{
+			`datname=~"[^"]*"(,\s*)?`,
+			`sys_id=~"[^"]*"(,\s*)?`,
+			`sys_scope=~"[^"]*"(,\s*)?`,
+			`sys_type=~"[^"]*"(,\s*)?`,
+		}
+
+		for _, pattern := range patterns {
+			match = regexp.MustCompile(pattern).ReplaceAllString(match, "")
+		}
+		if match == "{}" {
+			return ""
+		}
+		return match
+	})
+
+	// Clean up formatting and ensure proper system dimensions
+	query = strings.ReplaceAll(query, "  ", " ")
+	if strings.Contains(query, "datname") {
+		query = strings.ReplaceAll(query, "sum by(", "sum by(sys_id, sys_scope, sys_type,")
+	} else {
+		query = strings.ReplaceAll(query, "sum by(", "sum by(datname, sys_id, sys_scope, sys_type,")
+	}
+
+	return strings.TrimSpace(query)
+}
+
+// GeneratePrometheusConfig generates YAML configuration for Prometheus recording rules
+// The output format follows Prometheus recording rules specification
+func GeneratePrometheusConfig(groups []RecordingRuleGroup) string {
+	var sb strings.Builder
+	sb.WriteString("groups:\n")
+
+	for _, group := range groups {
+		sb.WriteString(fmt.Sprintf("  - name: %s\n", group.Name))
+		sb.WriteString(fmt.Sprintf("    interval: %s\n", group.Interval))
+		sb.WriteString("    rules:\n")
+
+		for _, rule := range group.Rules {
+			sb.WriteString(fmt.Sprintf("      - record: %s\n", rule.Name))
+			sb.WriteString(fmt.Sprintf("        expr: %s\n", rule.Expr))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -19,6 +19,7 @@ RUN wget -qO- https://github.com/prometheus/prometheus/releases/download/v2.55.1
 
 # Prometheus config
 COPY prometheus.yml ./config/prometheus/prometheus.yml
+COPY recording_rules.yml ./config/prometheus/recording_rules.yml
 
 COPY prometheus-entrypoint.sh /usr/local/autodba/bin/prometheus-entrypoint.sh
 RUN chmod +x /usr/local/autodba/bin/prometheus-entrypoint.sh

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -12,3 +12,6 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+rule_files:
+  - "recording_rules.yml"

--- a/prometheus/recording_rules.yml
+++ b/prometheus/recording_rules.yml
@@ -1,0 +1,117 @@
+groups:
+  - name: activity_cube_recording_rules_10m
+    interval: 10m
+    rules:
+      - record: cc_pg_stat_activity:sum_by_time__datname_10m
+        expr: sum by(sys_id, sys_scope, sys_type,datname) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_time__client_addr_10m
+        expr: sum by(datname, sys_id, sys_scope, sys_type,client_addr) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_time__application_name_10m
+        expr: sum by(datname, sys_id, sys_scope, sys_type,application_name) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_time__backend_type_10m
+        expr: sum by(datname, sys_id, sys_scope, sys_type,backend_type) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_time__query_10m
+        expr: sum by(datname, sys_id, sys_scope, sys_type,query) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_time__usename_10m
+        expr: sum by(datname, sys_id, sys_scope, sys_type,usename) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_time__wait_event_name_10m
+        expr: sum by(datname, sys_id, sys_scope, sys_type,wait_event_name) (cc_pg_stat_activity)
+      - record: cc_pg_stat_activity:sum_by_datname__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_datname__client_addr_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname, client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_datname__application_name_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname, application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_datname__backend_type_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname, backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_datname__query_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname, query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_datname__usename_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname, usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_datname__wait_event_name_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,datname, wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,client_addr, datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__client_addr_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__application_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,client_addr, application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__backend_type_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,client_addr, backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__query_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,client_addr, query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__usename_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,client_addr, usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_client_addr__wait_event_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,client_addr, wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,application_name, datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__client_addr_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,application_name, client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__application_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__backend_type_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,application_name, backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__query_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,application_name, query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__usename_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,application_name, usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_application_name__wait_event_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,application_name, wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,backend_type, datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__client_addr_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,backend_type, client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__application_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,backend_type, application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__backend_type_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__query_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,backend_type, query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__usename_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,backend_type, usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_backend_type__wait_event_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,backend_type, wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,query, datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__client_addr_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,query, client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__application_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,query, application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__backend_type_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,query, backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__query_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__usename_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,query, usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_query__wait_event_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,query, wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,usename, datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__client_addr_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,usename, client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__application_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,usename, application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__backend_type_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,usename, backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__query_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,usename, query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__usename_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_usename__wait_event_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,usename, wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__datname_10m
+        expr: avg_over_time(sum by(sys_id, sys_scope, sys_type,wait_event_name, datname) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__client_addr_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,wait_event_name, client_addr) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__application_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,wait_event_name, application_name) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__backend_type_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,wait_event_name, backend_type) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__query_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,wait_event_name, query) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__usename_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,wait_event_name, usename) (cc_pg_stat_activity)[21600s:600s])
+      - record: cc_pg_stat_activity:sum_by_wait_event_name__wait_event_name_10m
+        expr: avg_over_time(sum by(datname, sys_id, sys_scope, sys_type,wait_event_name) (cc_pg_stat_activity)[21600s:600s])
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -83,6 +83,7 @@ for arch in amd64 arm64; do
     echo "Copying prometheus setup files..."
     mkdir -p "${PROMETHEUS_CONFIG_DIR}"
     cp prometheus/prometheus.yml "${PROMETHEUS_CONFIG_DIR}/prometheus.yml"
+    cp prometheus/recording_rules.yml "${PROMETHEUS_CONFIG_DIR}/recording_rules.yml"
 
     echo "Building collector-api-server..."
     mkdir -p "${COLLECTOR_API_SERVER_DIR}"


### PR DESCRIPTION
This PR adds functionality to generate Prometheus recording rules for PostgreSQL activity metrics. The implementation includes:
 - A recording rules generator that creates pre-computed aggregations for activity metrics
- Support for different time scenarios and dimension combinations
